### PR TITLE
Integrate Github repos/issues with DynamoDB

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,6 +12,7 @@ import CreateTeamForm from './pages/forms/CreateTeamForm';
 import JoinTeamForm from './pages/forms/JoinTeamForm';
 import Team from './pages/Team';
 import AddMemberForm from './pages/forms/AddMemberForm';
+import AddProjectForm from './pages/forms/AddProjectForm';
 import ProjectBoard from './pages/ProjectBoard';
 
 export const UserContext = createContext();
@@ -43,6 +44,7 @@ const App = () => {
           <Route exact path="/team/create" component={CreateTeamForm} />
           <Route exact path="/team/join" component={JoinTeamForm} />
           <Route exact path="/team/add-member" component={AddMemberForm} />
+          <Route exact path="/team/add-project" component={AddProjectForm} />
           <Route exact path="/team/:teamName" component={Team} />
         </Switch>
         <Route exact path="/project/:projectId" component={ProjectBoard} />

--- a/client/src/components/material-ui/ProjectTable.jsx
+++ b/client/src/components/material-ui/ProjectTable.jsx
@@ -18,18 +18,14 @@ const useStyles = makeStyles({
   mainTableCell: {
     fontSize: '16px',
     fontWeight: 'bold',
-    teamRow: {
-      cursor: 'pointer',
-    },
+  },
+  projectRow: {
+    cursor: 'pointer',
     '&:hover': {
       backgroundColor: '#f4f4f4',
     },
   },
 });
-
-const createData = (projectName, totalTasks, assignedTasks, completedTasks) => {
-  return { projectName, totalTasks, assignedTasks, completedTasks };
-};
 
 const ProjectTable = (props) => {
   const classes = useStyles();
@@ -37,16 +33,12 @@ const ProjectTable = (props) => {
 
   useEffect(() => {
     if (props.projects) {
-      const projects = [];
-      props.projects.forEach((projectName) => {
-        projects.push(createData(projectName, 0, 0, 0, 0));
-      });
-      setRows(projects);
+      setRows(props.projects);
     }
   }, [props.projects]);
 
-  const goToTeamPage = (teamName) => {
-    props.history.push(`/team/${teamName}`);
+  const goToProjectPage = (projectName) => {
+    props.history.push(`/project/${projectName}`);
   };
 
   return (
@@ -71,14 +63,13 @@ const ProjectTable = (props) => {
         <TableBody>
           {rows.map((row) => (
             <TableRow
-              key={row.teamName}
-              className={classes.teamRow}
-              onClick={() => goToTeamPage(row.teamName)}
+              key={row.name}
+              className={classes.projectRow}
+              onClick={() => goToProjectPage(row.name)}
             >
               <TableCell component="th" scope="row">
-                {row.teamName}
+                {row.name}
               </TableCell>
-              <TableCell align="right">{row.totalProjects}</TableCell>
               <TableCell align="right">{row.totalTasks}</TableCell>
               <TableCell align="right">{row.assignedTasks}</TableCell>
               <TableCell align="right">{row.completedTasks}</TableCell>

--- a/client/src/components/material-ui/TeamTable.jsx
+++ b/client/src/components/material-ui/TeamTable.jsx
@@ -45,7 +45,7 @@ const TeamTable = (props) => {
     if (props.teams) {
       const teams = [];
       props.teams.forEach((teamName) => {
-        teams.push(createData(teamName, 0, 0, 0, 0));
+        teams.push(createData(teamName, -1, -1, -1, -1));
       });
       setRows(teams);
     }

--- a/client/src/pages/Dashboard.scss
+++ b/client/src/pages/Dashboard.scss
@@ -3,6 +3,7 @@
   display: flex;
   justify-content: space-around;
   align-items: center;
+  text-align: center;
 }
 
 .github__avatar {

--- a/client/src/pages/ProjectBoard.jsx
+++ b/client/src/pages/ProjectBoard.jsx
@@ -72,7 +72,7 @@ const ProjectBoard = (props) => {
   }, [props, isAuthenticated]);
 
   return (
-    <div className="dashboard__root">
+    <div className="project__root">
       <Navbar />
       <h1>hi, {githubUsername}</h1>
       <div className="tasks__container">

--- a/client/src/pages/ProjectBoard.scss
+++ b/client/src/pages/ProjectBoard.scss
@@ -1,4 +1,4 @@
-.dashboard__root {
+.project__root {
   text-align: center;
 }
 

--- a/client/src/pages/Team.jsx
+++ b/client/src/pages/Team.jsx
@@ -42,16 +42,23 @@ const Team = (props) => {
         const projectsApiResponse = await axios.get(
           `/api/projects/${projectName}`
         );
-        const projectInfo = {
-          name: projectName,
-          totalTasks: projectsApiResponse.data.issues.length,
-          assignedTasks: projectsApiResponse.data.issues.filter((issueObject) =>
-            issueObject.assignees.includes(githubUsername)
-          ).length,
-          completedTasks: projectsApiResponse.data.issues.filter(
-            (issueObject) => issueObject.status === 'DONE'
-          ).length,
-        };
+        const projectInfo = projectsApiResponse.data.issues
+          ? {
+              name: projectName,
+              totalTasks: projectsApiResponse.data.issues.length,
+              assignedTasks: projectsApiResponse.data.issues.filter(
+                (issueObject) => issueObject.assignees.includes(githubUsername)
+              ).length,
+              completedTasks: projectsApiResponse.data.issues.filter(
+                (issueObject) => issueObject.status === 'DONE'
+              ).length,
+            }
+          : {
+              name: projectName,
+              totalTasks: 0,
+              assignedTasks: 0,
+              completedTasks: 0,
+            };
         projectRows.push(projectInfo);
       }
 

--- a/client/src/pages/forms/AddMemberForm.jsx
+++ b/client/src/pages/forms/AddMemberForm.jsx
@@ -39,7 +39,9 @@ const AddMemberForm = (props) => {
         goBackToTeamPage();
       }
     } catch (error) {
-      setNotExistsError(true); // should never happen
+      // should never happen ATM
+      // TODO: (maybe) add checking if githubUsername actually exists
+      setNotExistsError(true);
     }
   };
 

--- a/client/src/pages/forms/AddProjectForm.jsx
+++ b/client/src/pages/forms/AddProjectForm.jsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useContext, useState } from 'react';
+import { UserContext } from '../../App';
+import axios from 'axios';
+
+import { TextField, Button } from '@material-ui/core';
+import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
+import Navbar from '../../components/material-ui/Navbar';
+import './AddProjectForm.scss';
+
+const AddProjectForm = (props) => {
+  const { isAuthenticated, githubUsername } = useContext(UserContext);
+  const { history } = props;
+  const [teamName, setTeamName] = useState('');
+  const [projectUrl, setProjectUrl] = useState('');
+
+  const [inputError, setInputError] = useState(false);
+  const [inputErrorText, setInputErrorText] = useState('');
+  const [notExistsError, setNotExistsError] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      history.push('/login');
+    }
+    setTeamName(props.location.state.teamName);
+  }, [history, isAuthenticated, props]);
+
+  const goBackToTeamPage = () => {
+    history.push({
+      pathname: `/team/${teamName}`,
+      state: { refreshFlag: true },
+    });
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    // Client side input validation
+    let trimmedUrl = projectUrl;
+    if (trimmedUrl.charAt(trimmedUrl.length - 1) === '/') {
+      trimmedUrl = trimmedUrl.substring(0, trimmedUrl.length - 1);
+    }
+    const splitUrl = trimmedUrl.split('/');
+
+    if (
+      (splitUrl[0] === 'https:' && splitUrl.length !== 5) ||
+      (splitUrl[0].includes('github.com') && splitUrl.length !== 3)
+    ) {
+      setInputError(true);
+      setInputErrorText('URL format is incorrect');
+    } else if (splitUrl[splitUrl.length - 2] !== githubUsername) {
+      setInputError(true);
+      setInputErrorText('Only repository owners can submit their projects');
+    } else {
+      setInputError(false);
+      const creatorUsername = splitUrl[splitUrl.length - 2];
+      const projectName = splitUrl[splitUrl.length - 1];
+
+      try {
+        const newProject = await axios.post('/api/projects/create', {
+          teamName,
+          creatorUsername,
+          projectName,
+        });
+        if (newProject) {
+          goBackToTeamPage();
+        }
+      } catch (error) {
+        setNotExistsError(true);
+      }
+    }
+  };
+
+  return (
+    <div>
+      <Navbar />
+      <div className="add__team__root">
+        <div>
+          <Button onClick={goBackToTeamPage}>
+            <ArrowBackIosIcon />
+            Back to Team
+          </Button>
+          <h1>Please enter Github repository URL:</h1>
+          <p>
+            Example: https://github.com/foo/
+            <span style={{ color: 'green' }}>trackr</span>
+          </p>
+          {inputError && <p className="error__message">{inputErrorText}</p>}
+          {notExistsError && (
+            <p className="error__message">
+              Repository does not exist or repository owner is not in team
+            </p>
+          )}
+          <form onSubmit={handleSubmit} noValidate autoComplete="off">
+            <TextField
+              onChange={(event) => setProjectUrl(event.target.value)}
+              id="outlined-secondary"
+              label="Github repository URL..."
+              variant="outlined"
+              color="secondary"
+              fullWidth={true}
+              style={{ marginBottom: '30px' }}
+            />
+            <Button variant="contained" color="secondary" type="submit">
+              Add Project
+            </Button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AddProjectForm;

--- a/server/routes/api/index.js
+++ b/server/routes/api/index.js
@@ -4,7 +4,9 @@ const router = express.Router();
 // API endpoints
 const authEndpoint = require('./authorization.controller');
 router.use('/auth', authEndpoint);
-const teamsEndpoint = require('./team.controller');
+const projectsEndpoint = require('./projects.controller');
+router.use('/projects', projectsEndpoint);
+const teamsEndpoint = require('./teams.controller');
 router.use('/teams', teamsEndpoint);
 const usersEndpoint = require('./users.controller');
 router.use('/users', usersEndpoint);

--- a/server/routes/api/projects.controller.js
+++ b/server/routes/api/projects.controller.js
@@ -1,0 +1,219 @@
+const express = require('express');
+const axios = require('axios');
+const projectsRouter = express.Router();
+const AWS = require('aws-sdk');
+const dynamoDB = new AWS.DynamoDB.DocumentClient();
+const TaskProgressEnum = require('../../utils/enums/tasks');
+
+// Checks if githubUsername is in teamName 'members' in DynamoDB
+const isUserInTeam = async (githubUsername, teamName) => {
+  const params = {
+    TableName: 'Teams',
+    Key: { teamName },
+  };
+
+  const teamInfo = await dynamoDB.get(params).promise();
+  return teamInfo.Item.members.includes(githubUsername);
+};
+
+/* Returns a promise that either resolves the required repo info, else rejects an error object */
+const getRepositoryInfo = async (githubUsername, projectName) => {
+  return new Promise(async (resolve, reject) => {
+    // Get all repos under githubUsername from Github API
+    const githubRepos = await axios.get(
+      `https://api.github.com/users/${githubUsername}/repos?sort=created`
+    );
+
+    // Filter for the repo with projectName
+    const repositoryInfo = githubRepos.data.filter(
+      (repoObject) => repoObject.name === projectName
+    );
+
+    // Assign repositoryId/repositoryName pointers if filter was successful, else reject with an error message
+    let repositoryId;
+    let repositoryName;
+    if (repositoryInfo.length !== 0) {
+      repositoryId = repositoryInfo[0].id;
+      repositoryName = repositoryInfo[0].name;
+    } else {
+      reject({
+        message:
+          'Project name does not exist as a repository under associated Github username',
+      });
+    }
+
+    // Get all issues under projectName from Github API
+    const githubIssues = await axios.get(
+      `https://api.github.com/repos/${githubUsername}/${projectName}/issues`
+    );
+
+    // Reduce the API response to an array of only needed info
+    const repositoryIssues = githubIssues.data.map((issueObject) => {
+      return {
+        id: issueObject.id,
+        title: issueObject.title,
+        description: issueObject.body,
+        status: TaskProgressEnum.TO_DO,
+        reporters: issueObject.user.login,
+        assignees: issueObject.assignees.map(
+          (assigneeObject) => assigneeObject.login
+        ),
+      };
+    });
+
+    resolve({
+      repositoryId,
+      repositoryName,
+      repositoryIssues,
+    });
+  });
+};
+
+// Checks if a projectName exists in the Projects table
+const doesProjectExistInDB = async (projectName) => {
+  const params = {
+    TableName: 'Projects',
+    Key: { projectName },
+  };
+
+  const lookup = await dynamoDB.get(params).promise();
+  return lookup.Item !== undefined && lookup.Item !== null ? true : false;
+};
+
+// Creates a new project in DB with projectName/projectId in the Projects table
+const createProjectInDB = async (repositoryInfo, teamName) => {
+  const { repositoryId, repositoryName, repositoryIssues } = repositoryInfo;
+
+  const projectParams = {
+    TableName: 'Projects',
+    Item: {
+      projectName: repositoryName,
+      projectId: repositoryId,
+    },
+    ReturnValues: 'ALL_OLD',
+  };
+
+  const teamParams = {
+    TableName: 'Teams',
+    Key: { teamName },
+    ReturnValues: 'ALL_NEW',
+    UpdateExpression:
+      'SET projects = list_append(if_not_exists(projects, :empty_list), :new_project)',
+    ExpressionAttributeValues: {
+      ':empty_list': [],
+      ':new_project': [repositoryName],
+    },
+  };
+
+  const createTaskResults = [];
+  if (repositoryIssues.length !== 0) {
+    projectParams.Item.issues = repositoryIssues;
+
+    // Writing to Tasks table in DB
+    for (const issueObject of repositoryIssues) {
+      const taskParams = {
+        TableName: 'Tasks',
+        Item: {
+          taskId: issueObject.id,
+          title: issueObject.title,
+          description: issueObject.description,
+          status: issueObject.status,
+          reporters: issueObject.reporters,
+          assignees: issueObject.assignees,
+        },
+        ReturnValues: 'ALL_OLD',
+      };
+
+      const createTaskResult = await dynamoDB.put(taskParams).promise();
+      createTaskResults.push(createTaskResult);
+    }
+  }
+
+  const createProjectResult = await dynamoDB.put(projectParams).promise();
+  const updateTeamResult = await dynamoDB.update(teamParams).promise();
+  return { createProjectResult, updateTeamResult, createTaskResults };
+};
+
+// Fetches information about an entry in Projects table with projectName
+const getProjectInformation = async (projectName) => {
+  const params = {
+    TableName: 'Projects',
+    Key: { projectName },
+  };
+
+  const projectInfo = await dynamoDB.get(params).promise();
+  return projectInfo.Item;
+};
+
+const isEmpty = (object) => {
+  return Object.keys(object).length === 0;
+};
+
+/**
+ * Creates a project entry in Projects table in DB using info from Github API
+ *
+ * Checks:
+ * • If creatorUsername is in team with teamName in DB
+ * • If the repository exists and is public under creatorUsername via Github API
+ * Then:
+ * • Creates an entry in DB about the current project (id, name, issues[])
+ */
+projectsRouter.post('/create', async (req, res) => {
+  const { cookies } = req;
+  const { teamName, creatorUsername, projectName } = req.body;
+
+  const isTeamMember = await isUserInTeam(creatorUsername, teamName);
+  if (!isTeamMember) {
+    res.status(400).json({
+      message:
+        'User entering project URL is not in current team, some malicious activity may be happening.',
+    });
+  }
+
+  try {
+    const repositoryInfo = await getRepositoryInfo(
+      creatorUsername,
+      projectName
+    );
+    const doesProjectExist = await doesProjectExistInDB(projectName);
+
+    if (doesProjectExist) {
+      res.status(400).json({ message: 'Project name already exists' });
+    } else {
+      const createResult = await createProjectInDB(repositoryInfo, teamName);
+      if (
+        isEmpty(createResult.createProjectResult) &&
+        !isEmpty(createResult.updateTeamResult)
+      ) {
+        res.status(200).json({ teamName, creatorUsername, projectName });
+      }
+    }
+  } catch (error) {
+    // Throw error when repository name doesn't exist under creatorUsername
+    res.status(400).json(error);
+  }
+});
+
+/**
+ * Gets all projects for a respective team
+ */
+projectsRouter.get('/:projectName', async (req, res) => {
+  const { projectName } = req.params;
+
+  if (!projectName) {
+    res.status(404).json({ message: 'Project name was not sent' });
+  }
+
+  const doesProjectExist = await doesProjectExistInDB(projectName);
+  if (doesProjectExist) {
+    const projectInfo = await getProjectInformation(projectName);
+    res.status(200).json({
+      projectName: projectInfo.projectName,
+      issues: projectInfo.issues,
+    });
+  } else {
+    res.status(400).json({ message: 'Project name does not exist' });
+  }
+});
+
+module.exports = projectsRouter;

--- a/server/routes/api/teams.controller.js
+++ b/server/routes/api/teams.controller.js
@@ -59,10 +59,7 @@ const joinMemberToTeamInDB = async (teamName, joiningUsername) => {
     Key: { teamName },
     ReturnValues: 'ALL_NEW',
     UpdateExpression:
-      'set members = list_append(if_not_exists(#members, :empty_list), :new_member)',
-    ExpressionAttributeNames: {
-      '#members': 'members',
-    },
+      'set members = list_append(if_not_exists(members, :empty_list), :new_member)',
     ExpressionAttributeValues: {
       ':empty_list': [],
       ':new_member': [joiningUsername],
@@ -204,7 +201,11 @@ teamsRouter.get('/:teamName', async (req, res) => {
     const teamInfo = await getTeamInformation(teamName);
     res
       .status(200)
-      .json({ teamName: teamInfo.teamName, members: teamInfo.members });
+      .json({
+        teamName: teamInfo.teamName,
+        members: teamInfo.members,
+        projects: teamInfo.projects,
+      });
   } else {
     res.status(400).json({ message: 'Team name does not exist' });
   }

--- a/server/utils/enums/tasks.js
+++ b/server/utils/enums/tasks.js
@@ -1,0 +1,8 @@
+const TaskProgressEnum = Object.freeze({
+  TO_DO: 'TO_DO',
+  IN_PROGRESS: 'IN_PROGESS',
+  IN_REVIEW: 'IN_REVIEW',
+  DONE: 'DONE',
+});
+
+module.exports = TaskProgressEnum;


### PR DESCRIPTION
Frontend changes:
* Adds `AddProjectForm` component that takes in a Github repository URL as input. It will validate the inputs on the client side such that the URL has the right format before hitting the server
* Makes the `ProjectTable` component consume data from DynamoDB about total, assigned, and completed tasks for any respective project
  * `TeamTable` currently shows all -1s on the main dashboard since it's not hooked up ATM

Backend changes:
* Adds `projects.controller` endpoint to handle creating/getting data about projects/issues associated with projects. Interacts with Github API to get the necessary data and then stores to DynamoDB


Example flow:
![projects-walkthru](https://user-images.githubusercontent.com/42355738/100185188-16f51800-2e98-11eb-8260-bdf03e6f6b13.gif)
