### PR TITLE
Add production dockerfile, nginx config, and docker-compose

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -18,4 +18,3 @@ EXPOSE 3000
 
 # Run the app
 CMD npm start
-

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -5,7 +5,7 @@ FROM node:14-alpine
 WORKDIR /app
 
 # Copy package.json before copying contents of project
-COPY package.json .
+COPY package*.json ./
 
 # Install dependencies from package.json
 RUN npm install

--- a/client/Dockerfile.prod
+++ b/client/Dockerfile.prod
@@ -1,0 +1,19 @@
+# Multi-stage Docker build for production
+
+# Stage 1: Build React app to static HTML CSS JS
+FROM node:14-alpine as build
+WORKDIR /app
+COPY package.json .
+COPY package-lock.json .
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Stage 2: Serve static build content from NGINX base image
+FROM nginx:1.19.5-alpine
+RUN rm /etc/nginx/conf.d/default.conf
+COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf
+# Get the build files to serve at root directory
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 3000
+CMD ["nginx", "-g", "daemon off;"]

--- a/client/nginx/nginx.conf
+++ b/client/nginx/nginx.conf
@@ -1,5 +1,14 @@
+upstream backendServer {
+	# In docker-compose file, we name the backend container 'server', so use that instead of 'localhost'
+	server server:5000;
+}
+
 server {
 	listen 3000;
+
+	location /api {
+		proxy_pass http://backendServer;
+	}
 
 	location / {
 		# Root directory

--- a/client/nginx/nginx.conf
+++ b/client/nginx/nginx.conf
@@ -1,0 +1,11 @@
+server {
+	listen 3000;
+
+	location / {
+		# Root directory
+		root /usr/share/nginx/html;
+		index index.html index.htm;
+
+		try_files $uri /index.html;
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3'
+services:
+  server:
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+    image: issue-tracker-backend
+    container_name: issue-tracker-express-server
+    restart: always
+    volumes:
+      - /server/node_modules
+    ports:
+      - "5000:5000"
+    networks:
+      - issue-tracker-network
+  client:
+    build:
+      context: ./client
+      dockerfile: Dockerfile.prod
+    image: issue-tracker-frontend-prod
+    container_name: issue-tracker-react-app
+    restart: always
+    volumes:
+      - /app/node_modules
+    depends_on:
+      - server
+    ports:
+      - "3000:3000"
+    networks:
+      - issue-tracker-network
+
+networks:
+  issue-tracker-network:
+    driver: bridge
+
+    

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install
 # copy other project files
 COPY . .
 
-#Expose port 5000
+# Expose port 5000
 EXPOSE 5000
 
 # build the folder

--- a/server/server.js
+++ b/server/server.js
@@ -25,5 +25,5 @@ server.listen(PORT, (error) => {
   if (error) {
     throw new Error(error);
   }
-  console.log('🔋 babu thomas 🔋');
+  console.log(`Express server listening on port ${PORT}`);
 });


### PR DESCRIPTION
This adds a production-grade `Dockerfile.prod` file for the frontend, it differs from the regular Dockerfile in that it builds the react app into static HTML/CSS/JS, then uses an NGINX base image to serve those static files

To build image:
```
cd client
docker build -f Dockerfile.prod -t <image-name> .
```
To test running (visit localhost:3000):
```
docker run -p 3000:3000 <image-name>
```

EDIT:
This now also adds a `docker-compose.yml` which allows us to replicate how the app would run in production. With one simple command `docker-compose up --build`, it will build the production images for the frontend/backend, and run them in a network. Then you can visit `localhost:3000` and NGINX will serve react files for all the pages, and any requests prefixed with `/api` will be proxied over to the express container